### PR TITLE
Hide Tip when the popover is closed in order to return the focus back to the previous app

### DIFF
--- a/mac-app/README.md
+++ b/mac-app/README.md
@@ -1,1 +1,4 @@
-Running tests: `xcodebuild -scheme "debug" test`
+* Running tests: `xcodebuild -scheme "debug" test`
+* Run `/System/Library/CoreServices/pbs -update` to update the list of services.
+* Run `/System/Library/CoreServices/pbs -dump` to see the list of services.
+* Run test `

--- a/mac-app/Tip/Info.plist
+++ b/mac-app/Tip/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.3.0-rc1</string>
 	<key>CFBundleVersion</key>
 	<string>5</string>
 	<key>LSApplicationCategoryType</key>

--- a/mac-app/Tip/Receiver.m
+++ b/mac-app/Tip/Receiver.m
@@ -19,11 +19,21 @@
     if (self) {
         self.tipper = tipper_;
         [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(popoverWillClose)
+                                                     name:NSPopoverWillCloseNotification
+                                                   object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(popoverDidClose)
                                                      name:NSPopoverDidCloseNotification
                                                    object:nil];
     }
     return self;
+}
+
+- (void) popoverWillClose {
+    // Trigger hiding in order to give the focus back to the previous app.
+    // Trigger hiding during NSPopoverWillCloseNotification is slicker.
+    [NSApp hide:nil];
 }
 
 - (void) popoverDidClose {
@@ -59,7 +69,6 @@
 }
 
 - (void)showPopover: (NSString*) input {
-    
     NSPoint mouseLoc = [NSEvent mouseLocation];
     
     NSRect frame = NSMakeRect(mouseLoc.x, mouseLoc.y-10, 1, 1);


### PR DESCRIPTION
This closes #31 