### PR TITLE
Make actions a bit quicker

### DIFF
--- a/mac-app/Tip.xcodeproj/project.pbxproj
+++ b/mac-app/Tip.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		F3A35D3223D636ED00982791 /* empty_provider.rb in Resources */ = {isa = PBXBuildFile; fileRef = F3A35D3123D636EC00982791 /* empty_provider.rb */; };
 		F3E5B64B23BA846A002BEDD6 /* FontAwesome-Solid.otf in Resources */ = {isa = PBXBuildFile; fileRef = F3E5B64A23BA846A002BEDD6 /* FontAwesome-Solid.otf */; };
 		FA0E180D23E6AD86006B4DD6 /* TipUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0E180C23E6AD86006B4DD6 /* TipUITests.swift */; };
+		FE22B0F02466787C008657DA /* single_action_provider.rb in Resources */ = {isa = PBXBuildFile; fileRef = FE22B0EF2466787C008657DA /* single_action_provider.rb */; };
+		FE22B0F2246678C3008657DA /* single_auto_action_provider.rb in Resources */ = {isa = PBXBuildFile; fileRef = FE22B0F1246678C3008657DA /* single_auto_action_provider.rb */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -79,6 +81,8 @@
 		F3E5B64A23BA846A002BEDD6 /* FontAwesome-Solid.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "FontAwesome-Solid.otf"; sourceTree = "<group>"; };
 		FA0E180723E6A7D3006B4DD6 /* TipUITests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "TipUITests-Bridging-Header.h"; sourceTree = "<group>"; };
 		FA0E180C23E6AD86006B4DD6 /* TipUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipUITests.swift; sourceTree = "<group>"; };
+		FE22B0EF2466787C008657DA /* single_action_provider.rb */ = {isa = PBXFileReference; lastKnownFileType = text.script.ruby; path = single_action_provider.rb; sourceTree = "<group>"; };
+		FE22B0F1246678C3008657DA /* single_auto_action_provider.rb */ = {isa = PBXFileReference; lastKnownFileType = text.script.ruby; path = single_auto_action_provider.rb; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -161,6 +165,8 @@
 				FA0E180C23E6AD86006B4DD6 /* TipUITests.swift */,
 				FA0E180723E6A7D3006B4DD6 /* TipUITests-Bridging-Header.h */,
 				F33EDCFA23DE262600114AFB /* unexecutable_provider.rb */,
+				FE22B0EF2466787C008657DA /* single_action_provider.rb */,
+				FE22B0F1246678C3008657DA /* single_auto_action_provider.rb */,
 			);
 			path = TipUITests;
 			sourceTree = "<group>";
@@ -269,8 +275,10 @@
 				F3A35D3223D636ED00982791 /* empty_provider.rb in Resources */,
 				F318018423D417F7000E17A5 /* good_provider.rb in Resources */,
 				F30099B523B8707B0000B9E3 /* RobotoMono-Regular.ttf in Resources */,
+				FE22B0F02466787C008657DA /* single_action_provider.rb in Resources */,
 				F33EDCFD23DE287200114AFB /* error_provider.rb in Resources */,
 				F3A35D2D23D6301200982791 /* malformed_json_provider.rb in Resources */,
+				FE22B0F2246678C3008657DA /* single_auto_action_provider.rb in Resources */,
 				F33EDCFB23DE262600114AFB /* unexecutable_provider.rb in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/mac-app/Tip/ExternalTipper.m
+++ b/mac-app/Tip/ExternalTipper.m
@@ -66,6 +66,7 @@
         NSString* type = [dict objectForKey:@"type"];
         NSString* value = [dict objectForKey:@"value"];
         NSString* label = [dict objectForKey:@"label"];
+        BOOL executeIfOnlyOne = [[dict objectForKey:@"executeIfOnlyOne"] boolValue];
         
         if (type == nil || value == nil) {
             NSLog(@"Malformed JSON: %@", [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
@@ -92,6 +93,8 @@
             }
             item.label = label;
         }
+        item.executeIfOnlyOne = executeIfOnlyOne;
+
         [items addObject:item];
     }
     

--- a/mac-app/Tip/Receiver.m
+++ b/mac-app/Tip/Receiver.m
@@ -65,10 +65,25 @@
         return;
     }
     
-    [self showPopover:input];
+    NSArray<TipItem *> * items;
+    @try {
+         items = [self.tipper makeTip:input];
+    } @catch (NSException* error) {
+        NSLog(@"Error: %@ %@", error, [error userInfo]);
+        _controller.error = error;
+        [self showPopover];
+        return;
+    }
+    _controller.items = items;
+    if (items.count == 1 && items[0].executeIfOnlyOne) {
+        [_controller performAction:0];
+        return;
+    }
+
+    [self showPopover];
 }
 
-- (void)showPopover: (NSString*) input {
+- (void)showPopover {
     NSPoint mouseLoc = [NSEvent mouseLocation];
     
     NSRect frame = NSMakeRect(mouseLoc.x, mouseLoc.y-10, 1, 1);
@@ -80,14 +95,6 @@
     [self.window setBackgroundColor:[NSColor colorWithRed:0 green:0 blue:0 alpha:0]];
     [self.window makeKeyAndOrderFront:NSApp];
     
-    @try {
-        NSArray<TipItem *> * items = [self.tipper makeTip:input];
-        _controller.items = items;
-    }
-    @catch (NSException* error) {
-        NSLog(@"Error: %@ %@", error, [error userInfo]);
-        _controller.error = error;
-    }
     self.popover = [[NSPopover alloc] init];
     self.popover.contentViewController = _controller;
     self.popover.behavior = NSPopoverBehaviorTransient;

--- a/mac-app/Tip/TipItem.h
+++ b/mac-app/Tip/TipItem.h
@@ -20,6 +20,7 @@ typedef enum TipItemType : NSUInteger {
 @property TipItemType type;
 @property NSString *label;
 @property NSString *value;
+@property BOOL executeIfOnlyOne;
 
 @end
 

--- a/mac-app/Tip/TipTableController.h
+++ b/mac-app/Tip/TipTableController.h
@@ -22,6 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property NSTableColumn* iconColumn;
 @property NSTableColumn* textColumn;
 
+- (void) performAction:(NSUInteger)row;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/mac-app/Tip/TipTableController.m
+++ b/mac-app/Tip/TipTableController.m
@@ -68,6 +68,9 @@
     _error = nil;
     [self update];
     [_table reloadData];
+    if (items.count > 0) {
+        [_table selectRowIndexes:[NSIndexSet indexSetWithIndex:0] byExtendingSelection:NO];
+    }
 }
 
 - (void)update {

--- a/mac-app/TipUITests/TipUITests.swift
+++ b/mac-app/TipUITests/TipUITests.swift
@@ -35,6 +35,20 @@ final class TipUITests : XCTestCase {
     XCTAssertEqual("tanintip://TestInput", pasteBoard.string(forType: .string))
   }
 
+  func testSingleProviderClickingOnTextWithLabel() {
+    launch(withName: "single_action_provider")
+    usleep(useconds_t(200 * 1000))
+    XCTAssertEqual("Label TestInput", getLabel(rowIndex: 0))
+    click(rowIndex: 0)
+    XCTAssertEqual("Return TestInput", pasteBoard.string(forType: .string))
+  }
+
+  func testSingleProviderAutoAction() {
+    launch(withName: "single_auto_action_provider")
+    XCTAssertEqual(app.popovers.count, 0)
+    XCTAssertEqual("Return Auto TestInput", pasteBoard.string(forType: .string))
+  }
+
   func testNoProvider() {
     app.launchArguments = ["-test", "TestInput", "-provider", "/tmp/something-doesn-exist.rb"]
     app.launch()

--- a/mac-app/TipUITests/good_provider.rb
+++ b/mac-app/TipUITests/good_provider.rb
@@ -17,6 +17,12 @@ def main(input)
        type: 'url',
        label: "Go to #{input}",
        value: "tanintip://#{input}"
+    },
+    {
+       type: 'text',
+       label: "Label Auto #{input}",
+       value: "Return Auto #{input}",
+       executeIfOnlyOne: true
     }
   ].to_json
 end

--- a/mac-app/TipUITests/single_action_provider.rb
+++ b/mac-app/TipUITests/single_action_provider.rb
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+require 'json'
+
+def main(input)
+  puts [
+    {
+       type: 'text',
+       label: "Label #{input}",
+       value: "Return #{input}"
+    }
+  ].to_json
+end
+
+
+if __FILE__ == $0
+  main(ARGV[0])
+end

--- a/mac-app/TipUITests/single_auto_action_provider.rb
+++ b/mac-app/TipUITests/single_auto_action_provider.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+
+require 'json'
+
+def main(input)
+  puts [
+    {
+       type: 'text',
+       label: "Label Auto #{input}",
+       value: "Return Auto #{input}",
+       executeIfOnlyOne: TRUE
+    }
+  ].to_json
+end
+
+
+if __FILE__ == $0
+  main(ARGV[0])
+end
+


### PR DESCRIPTION
Highlight first tip in tooltip to allow immediately pressing enter to quickly select it.
If there is only one result, don't bother displaying the tooltip, just launch the action - especially useful for jira actions if the default google action is removed.