### PR TITLE
Allow row heights to be flexible based on text content.

### DIFF
--- a/mac-app/Tip/TipTableController.m
+++ b/mac-app/Tip/TipTableController.m
@@ -35,6 +35,7 @@
         _table.target = self;
         _table.intercellSpacing = CGSizeMake(0, 0);
         _table.hidden = YES;
+        _table.usesAutomaticRowHeights = YES;
         
         _iconColumn = [[NSTableColumn alloc] initWithIdentifier:@"icon"];
         _iconColumn.width = 18;
@@ -162,10 +163,6 @@
     return textField;
 }
 
-- (CGFloat)tableView:(NSTableView *)tableView heightOfRow:(NSInteger)row {
-    return 22;
-}
-
 - (nullable NSView *)tableView:(NSTableView *)tableView viewForTableColumn:(nullable NSTableColumn *)tableColumn row:(NSInteger)row {
     NSView* result = [tableView makeViewWithIdentifier:tableColumn.identifier owner:self];
     TipItem* item = [_items objectAtIndex:row];
@@ -184,6 +181,7 @@
             iconText.selectable = NO;
             iconText.bezeled = NO;
             iconText.drawsBackground = NO;
+            iconText.autoresizingMask = NSViewHeightSizable;
                     
             [icon addSubview:iconText];
         }


### PR DESCRIPTION
Thanks for Tip! I work a _lot_ with JWTs, and frequently need to inspect their contents. Tip is perfect for that, except that it seems to not support multiline text currently. After a bit of fiddling (I'm 0/10 in OSX native dev) I seem to have this working by using auto-layout on the table.

See attached examples...

## Before:
<img width="504" alt="Screen Shot 2020-05-09 at 7 09 58 PM" src="https://user-images.githubusercontent.com/480677/81488674-2b89ff80-9229-11ea-91ef-eb68fa5c03a4.png">

## After:
<img width="501" alt="Screen Shot 2020-05-09 at 7 10 23 PM" src="https://user-images.githubusercontent.com/480677/81488678-36dd2b00-9229-11ea-90a4-986e34f5ffb7.png">
