### PR TITLE
Add text length and base64 encode/decode actions

### DIFF
--- a/scripts/provider.script
+++ b/scripts/provider.script
@@ -4,6 +4,7 @@
 
 require 'json'
 require 'cgi'
+require 'base64'
 
 def main(input)
   input = input.strip
@@ -12,6 +13,9 @@ def main(input)
   items += get_jira_url(input)
   items += get_google_url(input)
   items += get_definition(input)
+  items += get_to_base64(input)
+  items += get_from_base64(input)
+  items += get_text_length(input)
 
   puts items.compact.to_json
 end
@@ -68,6 +72,38 @@ def get_definition(input)
        label: 'Open Dictionary',
        value: "https://www.dictionary.com/browse/#{input}"
   }]
+end
+
+def get_to_base64(input)
+  base64 = Base64.strict_encode64(input)
+  return [{
+       type: 'text',
+       label: 'Convert to BASE64',
+       value: base64
+  }]
+end
+
+def get_from_base64(input)
+  begin
+    return [] unless /^[a-zA-Z0-9\/=]+$/.match(input)
+    base64 = Base64.strict_decode64(input)
+    return [] unless Base64.strict_encode64(base64) == input
+    [{
+       type: 'text',
+       label: 'Convert from BASE64',
+       value: base64
+    }]
+  end
+end
+
+def get_text_length(input)
+  begin
+    [{
+       type: 'text',
+       label: 'Text length: ' + input.length.to_s,
+       value: input.length.to_s
+    }]
+  end
 end
 
 if __FILE__ == $0

--- a/scripts/provider.script
+++ b/scripts/provider.script
@@ -84,16 +84,14 @@ def get_to_base64(input)
 end
 
 def get_from_base64(input)
-  begin
-    return [] unless /^[a-zA-Z0-9\/=]+$/.match(input)
-    base64 = Base64.strict_decode64(input)
-    return [] unless Base64.strict_encode64(base64) == input
-    [{
-       type: 'text',
-       label: 'Convert from BASE64',
-       value: base64
-    }]
-  end
+  return [] unless /^[a-zA-Z0-9\/=]+$/.match(input)
+  base64 = Base64.strict_decode64(input)
+  return [] unless Base64.strict_encode64(base64) == input
+  [{
+     type: 'text',
+     label: 'Convert from BASE64',
+     value: base64
+  }]
 end
 
 def get_text_length(input)

--- a/scripts/provider.script
+++ b/scripts/provider.script
@@ -95,13 +95,11 @@ def get_from_base64(input)
 end
 
 def get_text_length(input)
-  begin
-    [{
-       type: 'text',
-       label: 'Text length: ' + input.length.to_s,
-       value: input.length.to_s
-    }]
-  end
+  [{
+     type: 'text',
+     label: 'Text length: ' + input.length.to_s,
+     value: input.length.to_s
+  }]
 end
 
 if __FILE__ == $0


### PR DESCRIPTION
This pull request adds three new actions, one for the text length, two for base64 manipulation. 

I think it would be cool to have a "transform" type of action where the action would only be executed after the user actually chooses it, that way various digest actions could be added (sha256, sha512, etc) but they wouldn't be executed automatically and wouldn't slow down the UI. 